### PR TITLE
Fix CS:GO Linux signatures

### DIFF
--- a/sourcetvmanager.games.txt
+++ b/sourcetvmanager.games.txt
@@ -33,7 +33,7 @@
 				"linux"
 				{
 					"signature"	"CHLTVServer_DemoRecorderRef"
-					"read"	"38"
+					"read"	"43"
 				}
 			}
 		}
@@ -143,7 +143,7 @@
 			{
 				"library"	"engine"
 				// _ZN11CHLTVServer26StopRecordingAndFreeFramesEbPK9CGameInfo
-				"linux"	"\x55\x89\xE5\x57\x56\x53\x83\xEC\x3C\x8B\x5D\x08\x8B\x55\x10\x0F\xB6\x7D\x0C"
+				"linux"	"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x75\x08\x0F\xB6\x45\x0C"
 				// _ZN11CHLTVServer11IsRecordingEv
 				"windows" "\x8B\x81\x2A\x2A\x2A\x2A\x81\xC1\x2A\x2A\x2A\x2A\x8B\x40\x2A\xFF\xE0"
 			}


### PR DESCRIPTION
Should fix the broken m_DemoRecorder offset from the last big CS:GO update.