### PR TITLE
Fix spectator message handling in TF2

### DIFF
--- a/forwards.h
+++ b/forwards.h
@@ -86,7 +86,10 @@ public:
 	void CallOnSpectatorChatMessage_Post(HLTVServerWrapper *server, const char *msg, const char *chatgroup);
 
 	bool OnSpectatorExecuteStringCommand(const char *s);
+	bool BaseClient_OnSpectatorExecuteStringCommand(const char *s);
+	bool HandleOnSpectatorExecuteStringCommand(IClient *client, const char *s);
 	bool OnSpectatorExecuteStringCommand_Post(const char *s);
+
 	void CreateBroadcastLocalChatDetour();
 	void RemoveBroadcastLocalChatDetour();
 
@@ -134,6 +137,7 @@ private:
 	bool m_bHasGetChallengeTypeOffset = false;
 	bool m_bHasActivatePlayerOffset = false;
 	bool m_bHasDisconnectOffset = false;
+	bool m_bHasExecuteStringCommandOffset = false;
 
 	bool m_bBroadcastLocalChatDetoured = false;
 	CDetour *m_DBroadcastLocalChat = nullptr;

--- a/sourcetvmanager.games.txt
+++ b/sourcetvmanager.games.txt
@@ -258,6 +258,11 @@
 				"linux"	"2"
 			}
 			
+			"CBaseClient::ExecuteStringCommand"
+			{
+				"linux"	"22"
+			}
+			
 			"CBaseClient::Disconnect"
 			{
 				"linux"	"14"


### PR DESCRIPTION
`CBaseClient::ExecuteStringCommand` wasn't getting hooked; PR is a quick hackjob to fix it.  Not intended to be immediately merged, of course.

Successfully works in TF2 / Linux, untested on other games.

Ran a test build of it against Windows which did not work; probably going to need to update the gamedata on that.  Deosn't seem like the chat hooks are working at all, as it seems to be hooked against a different virtual function.

I believe part of it's a multiple inheritance quirk.