### PR TITLE
Set _GLIBCXX_USE_CXX11_ABI to 0

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -353,6 +353,7 @@ class ExtensionConfig(object):
 
     if sdk.name == 'csgo' and builder.target_platform == 'linux':
       compiler.linkflags += ['-lstdc++']
+      compiler.defines += ['_GLIBCXX_USE_CXX11_ABI=0']
 
     for path in paths:
       compiler.cxxincludes += [os.path.join(sdk.path, *path)]


### PR DESCRIPTION
Fix for builds against souremod 1.10 and csgo(?) linux servers.

Build loads fine without any cxx11 errors like before.

[My build](https://csgottt.com/sourcetvmanager-package.zip) (Compiled against [latest sourcemod](https://github.com/alliedmodders/sourcemod/tree/14227c04b857fbaf2e86d83f4cb545d0928959a0) on [debian 8](https://csgottt.com/sourcetvmanager-package.zip), [sourcecode](https://github.com/Bara/sourcetvmanager/tree/patch-1))