### PR TITLE
Fix spectator message handling in TF2 on linux

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -174,6 +174,7 @@ class ExtensionConfig(object):
       '-Wno-switch',
       '-Wno-array-bounds',
       '-Wno-expansion-to-defined',
+      '-Wno-implicit-const-int-float-conversion',
       '-msse',
       '-m32',
       '-fvisibility=hidden',

--- a/commonhooks.h
+++ b/commonhooks.h
@@ -36,8 +36,12 @@ class IClient;
 class CForwardManager;
 class HLTVServerWrapper;
 
+#define NEED_EXECUTESTRINGCMD_CBASECLIENT !defined(WIN32) && SOURCE_ENGINE == SE_TF2
+
 class CCommonHooks {
 public:
+	void Init();
+
 	// For forwards
 	void AddSpectatorHook(CForwardManager *fwdmgr, IClient *client);
 	void RemoveSpectatorHook(CForwardManager *fwdmgr, IClient *client);
@@ -45,6 +49,11 @@ public:
 	// For host_client and status fix
 	void AddHLTVClientHook(HLTVServerWrapper *wrapper, IClient *client);
 	void RemoveHLTVClientHook(HLTVServerWrapper *wrapper, IClient *client);
+
+private:
+#ifdef NEED_EXECUTESTRINGCMD_CBASECLIENT
+	bool m_bHasExecuteStringCommandOffset = false;
+#endif
 };
 
 extern CCommonHooks g_pSTVCommonHooks;

--- a/forwards.h
+++ b/forwards.h
@@ -85,7 +85,8 @@ public:
 	bool CallOnSpectatorChatMessage(HLTVServerWrapper *server, char *msg, int msglen, char *chatgroup, int grouplen);
 	void CallOnSpectatorChatMessage_Post(HLTVServerWrapper *server, const char *msg, const char *chatgroup);
 
-	bool OnSpectatorExecuteStringCommand(const char *s);
+	bool BaseClient_OnSpectatorExecuteStringCommand(const char *s);
+	bool IClient_OnSpectatorExecuteStringCommand(const char *s);
 	bool OnSpectatorExecuteStringCommand_Post(const char *s);
 	void CreateBroadcastLocalChatDetour();
 	void RemoveBroadcastLocalChatDetour();
@@ -114,6 +115,7 @@ private:
 
 private:
 	void HandleSpectatorDisconnect(IClient *client, const char *reason);
+	void HandleSpectatorExecuteStringCommand(IClient *client, const char *s);
 
 private:
 	IForward *m_StartRecordingFwd;

--- a/sourcetvmanager.games.txt
+++ b/sourcetvmanager.games.txt
@@ -263,6 +263,11 @@
 				"linux"	"14"
 			}
 			
+			"CBaseClient::ExecuteStringCommand"
+			{
+				"linux"	"22"
+			}
+			
 			"CHLTVServer::Shutdown"
 			{
 				"windows"	"41"
@@ -289,6 +294,11 @@
 			"CHLTVDemoRecorder_BaseOffset"
 			{
 				"windows"	"0"
+				"linux"	"4"
+			}
+
+			"IServer_from_CHLTVServer"
+			{
 				"linux"	"4"
 			}
 		}


### PR DESCRIPTION
Basic fix by @nosoop changed to only be used in tf2 instead of all games.
This is a follow up to #9.