### PR TITLE
ci ubuntu 22.04 -> 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             meta_version: "1.11"
             meta_branch: "1.11-dev"
             
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             os_short: linux
             
           - os: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - windows-latest
           
         sm_version:


### PR DESCRIPTION
fixes very new glibc dependency (2.32). debian 11 is only on 2.31. Please dont make me upgrade my entire toolchain lol